### PR TITLE
Fix error when brew tap and add bundle cask

### DIFF
--- a/ansible/roles/homebrew/vars/main.yml
+++ b/ansible/roles/homebrew/vars/main.yml
@@ -1,7 +1,6 @@
 ---
 homebrew_taps:
-  - { name: homebrew/cask,      state: present }
-  - { name: homebrew/core,      state: present }
+  - { name: homebrew/bundle,    state: present }
   - { name: homebrew/services,  state: present }
 
 homebrew_installed_packages:


### PR DESCRIPTION
Fix the following error when brew tap.  

- Error: Tapping homebrew/cask is no longer typically necessary.
- Error: Tapping homebrew/core is no longer typically necessary.

and, add [homebrew-bundle](https://github.com/Homebrew/homebrew-bundle) cask.